### PR TITLE
Resolving early termination due to protocol URL

### DIFF
--- a/view/frontend/templates/widget_script.phtml
+++ b/view/frontend/templates/widget_script.phtml
@@ -1,4 +1,4 @@
 <script type="text/javascript">
-(function e(){var e=document.createElement("script");e.type="text/javascript",e.async=true,e.src="<?php echo getenv("TEST_ENV_WIDGET") ?: "//staticw2.yotpo.com"; ?>/<?php echo $this->_config->getAppKey(); ?>/widget.js ";var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t)})();
+(function e(){var e=document.createElement("script");e.type="text/javascript",e.async=true,e.src="<?php echo getenv("TEST_ENV_WIDGET") ?: "https://staticw2.yotpo.com"; ?>/<?php echo $this->_config->getAppKey(); ?>/widget.js ";var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t)})();
 </script>
 


### PR DESCRIPTION
The protocol-relative URL was causing this script to terminate early on "compilation." The result in the static deployed files (causing an HTTP Error 500) appeared as: 

```
<script type="text/javascript">
(function e(){var e=document.createElement("script");e.type="text/javascript",e.async=true,e.src="<?php echo getenv("TEST_ENV_WIDGET") ?: "</script>
```

This behavior was observed consistently across development, staging, and production environments.

As of December 2014, [Paul Irish's blog](https://www.paulirish.com/2010/the-protocol-relative-url/) on protocol-relative URLs says "2014.12.17: Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the https:// asset."

My observation is that static resources served through Yotpo are already secure and thus should be enforced using https instead of protocol-relative urls. Changing the url specificity to https resolved the issue and is, in any regard, more secure. 