### PR TITLE
v2.8.3

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
+++ b/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
@@ -63,6 +63,18 @@ class SyncStatus extends \Magento\Config\Block\System\Config\Form\Field
     }
 
     /**
+     * Remove scope label
+     *
+     * @param  AbstractElement $element
+     * @return string
+     */
+    public function render(AbstractElement $element)
+    {
+        $element->unsScope()->unsCanUseWebsiteValue()->unsCanUseDefaultValue();
+        return parent::render($element);
+    }
+
+    /**
      * Return element html
      *
      * @param  AbstractElement $element
@@ -102,7 +114,7 @@ class SyncStatus extends \Magento\Config\Block\System\Config\Form\Field
         $collection = $this->_orderCollectionFactory->create();
         $collection->getSelect()->joinLeft(
             ['yotpo_sync'=>$collection->getTable('yotpo_sync')],
-              "main_table.entity_id = yotpo_sync.entity_id AND main_table.store_id = yotpo_sync.store_id AND yotpo_sync.entity_type = 'orders'",
+            "main_table.entity_id = yotpo_sync.entity_id AND main_table.store_id = yotpo_sync.store_id AND yotpo_sync.entity_type = 'orders'",
             [
                 'yotpo_sync_flag'=>'yotpo_sync.sync_flag'
             ]

--- a/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
+++ b/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
@@ -141,13 +141,13 @@ class SyncStatus extends \Magento\Config\Block\System\Config\Form\Field
 
         foreach ($this->getStoreIds() as $key => $storeId) {
             $status['total_orders'] += $this->getOrderCollection()
-                ->addAttributeToFilter('main_table.status', $this->_yotpoHelper->getCustomOrderStatus($storeId, ScopeInterface::SCOPE_STORE))
+                ->addAttributeToFilter('main_table.status', ['in' => $this->_yotpoHelper->getCustomOrderStatus($storeId, ScopeInterface::SCOPE_STORE)])
                 ->addAttributeToFilter('main_table.store_id', $storeId)
                 ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($storeId, ScopeInterface::SCOPE_STORE)])
                 ->getSize();
 
             $status['total_orders_synced'] += $this->getOrderCollection()
-                ->addAttributeToFilter('main_table.status', $this->_yotpoHelper->getCustomOrderStatus($storeId, ScopeInterface::SCOPE_STORE))
+                ->addAttributeToFilter('main_table.status', ['in' => $this->_yotpoHelper->getCustomOrderStatus($storeId, ScopeInterface::SCOPE_STORE)])
                 ->addAttributeToFilter('main_table.store_id', $storeId)
                 ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($storeId, ScopeInterface::SCOPE_STORE)])
                 ->addAttributeToFilter('yotpo_sync.sync_flag', 1)

--- a/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
+++ b/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
@@ -145,9 +145,13 @@ class SyncStatus extends \Magento\Config\Block\System\Config\Form\Field
                 ->addAttributeToFilter('main_table.store_id', $storeId)
                 ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($storeId, ScopeInterface::SCOPE_STORE)])
                 ->getSize();
-
+            $status['total_orders'] += $this->getOrderCollection()
+                ->addAttributeToFilter('main_table.status', ['nin' => $this->_yotpoHelper->getCustomOrderStatus($storeId, ScopeInterface::SCOPE_STORE)])
+                ->addAttributeToFilter('main_table.store_id', $storeId)
+                ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($storeId, ScopeInterface::SCOPE_STORE)])
+                ->addAttributeToFilter('yotpo_sync.sync_flag', 1)
+                ->getSize();
             $status['total_orders_synced'] += $this->getOrderCollection()
-                ->addAttributeToFilter('main_table.status', ['in' => $this->_yotpoHelper->getCustomOrderStatus($storeId, ScopeInterface::SCOPE_STORE)])
                 ->addAttributeToFilter('main_table.store_id', $storeId)
                 ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($storeId, ScopeInterface::SCOPE_STORE)])
                 ->addAttributeToFilter('yotpo_sync.sync_flag', 1)

--- a/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
+++ b/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
@@ -136,15 +136,15 @@ class SyncStatus extends \Magento\Config\Block\System\Config\Form\Field
         $status = [];
 
         $status['total_orders'] = (!$this->getStoreIds()) ? 0 : $this->getOrderCollection()
-            ->addAttributeToFilter('main_table.status', $this->_yotpoHelper->getCustomOrderStatus())
+            ->addAttributeToFilter('main_table.status', $this->_yotpoHelper->getCustomOrderStatus($this->getStoreId(), ScopeInterface::SCOPE_STORE))
             ->addAttributeToFilter('main_table.store_id', ['in' => $this->getStoreIds()])
-            ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate()])
+            ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($this->getStoreId(), ScopeInterface::SCOPE_STORE)])
             ->getSize();
 
         $status['total_orders_synced'] = (!$this->getStoreIds()) ? 0 : $this->getOrderCollection()
-            ->addAttributeToFilter('main_table.status', $this->_yotpoHelper->getCustomOrderStatus())
+            ->addAttributeToFilter('main_table.status', $this->_yotpoHelper->getCustomOrderStatus($this->getStoreId(), ScopeInterface::SCOPE_STORE))
             ->addAttributeToFilter('main_table.store_id', ['in' => $this->getStoreIds()])
-            ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate()])
+            ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($this->getStoreId(), ScopeInterface::SCOPE_STORE)])
             ->addAttributeToFilter('yotpo_sync.sync_flag', 1)
             ->getSize();
 

--- a/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
+++ b/Block/Adminhtml/System/Config/Form/Field/SyncStatus.php
@@ -136,6 +136,7 @@ class SyncStatus extends \Magento\Config\Block\System\Config\Form\Field
         $status = [
             'total_orders' => 0,
             'total_orders_synced' => 0,
+            'total_orders_synced_all' => 0,
             'last_sync_date' => "never",
         ];
 
@@ -145,13 +146,13 @@ class SyncStatus extends \Magento\Config\Block\System\Config\Form\Field
                 ->addAttributeToFilter('main_table.store_id', $storeId)
                 ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($storeId, ScopeInterface::SCOPE_STORE)])
                 ->getSize();
-            $status['total_orders'] += $this->getOrderCollection()
-                ->addAttributeToFilter('main_table.status', ['nin' => $this->_yotpoHelper->getCustomOrderStatus($storeId, ScopeInterface::SCOPE_STORE)])
+            $status['total_orders_synced'] += $this->getOrderCollection()
+                ->addAttributeToFilter('main_table.status', ['in' => $this->_yotpoHelper->getCustomOrderStatus($storeId, ScopeInterface::SCOPE_STORE)])
                 ->addAttributeToFilter('main_table.store_id', $storeId)
                 ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($storeId, ScopeInterface::SCOPE_STORE)])
                 ->addAttributeToFilter('yotpo_sync.sync_flag', 1)
                 ->getSize();
-            $status['total_orders_synced'] += $this->getOrderCollection()
+            $status['total_orders_synced_all'] += $this->getOrderCollection()
                 ->addAttributeToFilter('main_table.store_id', $storeId)
                 ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate($storeId, ScopeInterface::SCOPE_STORE)])
                 ->addAttributeToFilter('yotpo_sync.sync_flag', 1)

--- a/Console/Command/SyncCommand.php
+++ b/Console/Command/SyncCommand.php
@@ -108,12 +108,6 @@ class SyncCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->_yotpoHelper = $this->_objectManager->get('\Yotpo\Yotpo\Helper\Data');
-
-        if (!$this->_yotpoHelper->isEnabled()) {
-            $output->writeln('<error>' . 'The Yotpo Yotpo module has been disabled from system configuration. Please enable it in order to run this command!' . '</error>');
-            return;
-        }
-
         $this->_jobs = $this->_objectManager->get('\Yotpo\Yotpo\Cron\Jobs');
 
         $this->_registry->register('isYotpoOrdersSyncCommand', true);

--- a/Console/Command/UpdateMetadataCommand.php
+++ b/Console/Command/UpdateMetadataCommand.php
@@ -83,12 +83,6 @@ class UpdateMetadataCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->_yotpoHelper = $this->_objectManager->get('\Yotpo\Yotpo\Helper\Data');
-
-        if (!$this->_yotpoHelper->isEnabled()) {
-            $output->writeln('<error>' . 'The Yotpo Yotpo module has been disabled from system configuration. Please enable it in order to run this command!' . '</error>');
-            return;
-        }
-
         $this->_jobs = $this->_objectManager->get('\Yotpo\Yotpo\Cron\Jobs');
 
         $this->_registry->register('isUpdateMetadataCommand', true);

--- a/Cron/Jobs.php
+++ b/Cron/Jobs.php
@@ -206,25 +206,21 @@ class Jobs
     public function updateMetadata()
     {
         try {
-            if ($this->_yotpoHelper->isEnabled()) {
-                $this->_processOutput("Jobs::updateMetadata() - [STARTED]", "info");
-                $this->setCrontabAreaCode();
-                foreach ($this->_yotpoHelper->getAllStoreIds(false) as $storeId) {
-                    try {
-                        $this->_yotpoHelper->emulateFrontendArea($storeId, true);
-                        if (!$this->_yotpoHelper->isEnabled()) {
-                            $this->_processOutput("Jobs::updateMetadata() - Skipping store ID: {$storeId} (disabled)", "info");
-                            continue;
-                        }
-                        $this->_processOutput("Jobs::updateMetadata() - Updating metadata for store ID: {$storeId} ...", "info");
-                        $result = $this->_yotpoApi->updateMetadata($storeId);
-                        $this->_processOutput("Jobs::updateMetadata() - Updating metadata for store ID: {$storeId} [SUCCESS]", "info");
-                    } catch (\Exception $e) {
-                        $this->_processOutput("Jobs::updateMetadata() - Exception on store ID: {$storeId} - " . $e->getMessage() . "\n" . $e->getTraceAsString(), "error");
+            $this->setCrontabAreaCode();
+            foreach ($this->_yotpoHelper->getAllStoreIds(false) as $storeId) {
+                try {
+                    $this->_yotpoHelper->emulateFrontendArea($storeId, true);
+                    if (!$this->_yotpoHelper->isEnabled()) {
+                        $this->_processOutput("Jobs::updateMetadata() - Skipping store ID: {$storeId} (disabled)", "info");
+                        continue;
                     }
-                    $this->_yotpoHelper->stopEnvironmentEmulation();
+                    $this->_processOutput("Jobs::updateMetadata() - Updating metadata for store ID: {$storeId} ...", "info");
+                    $result = $this->_yotpoApi->updateMetadata($storeId);
+                    $this->_processOutput("Jobs::updateMetadata() - Updating metadata for store ID: {$storeId} [SUCCESS]", "info");
+                } catch (\Exception $e) {
+                    $this->_processOutput("Jobs::updateMetadata() - Exception on store ID: {$storeId} - " . $e->getMessage() . "\n" . $e->getTraceAsString(), "error");
                 }
-                $this->_processOutput("Jobs::updateMetadata() - [DONE]", "info");
+                $this->_yotpoHelper->stopEnvironmentEmulation();
             }
         } catch (\Exception $e) {
             $this->_processOutput("Jobs::updateMetadata() - Exception:  " . $e->getMessage() . "\n" . $e->getTraceAsString(), "error");
@@ -250,9 +246,7 @@ class Jobs
     public function ordersSync()
     {
         try {
-            $this->_processOutput("Jobs::ordersSync() - [STARTED]", "info");
             $this->setCrontabAreaCode();
-
             foreach ($this->_yotpoHelper->getAllStoreIds(false) as $storeId) {
                 try {
                     $this->_yotpoHelper->emulateFrontendArea($storeId, true);
@@ -298,8 +292,6 @@ class Jobs
                 }
                 $this->_yotpoHelper->stopEnvironmentEmulation();
             }
-
-            $this->_processOutput("Jobs::ordersSync() - [DONE]", "info");
         } catch (\Exception $e) {
             $this->_processOutput("Jobs::ordersSync() - Exception: Failed to sync orders. " . $e->getMessage() . "\n" . $e->getTraceAsString(), "error");
         }

--- a/Cron/Jobs.php
+++ b/Cron/Jobs.php
@@ -271,7 +271,7 @@ class Jobs
                     }
 
                     $ordersCollection = $this->getOrderCollection()
-                            ->addAttributeToFilter('main_table.status', $this->_yotpoHelper->getCustomOrderStatus())
+                            ->addAttributeToFilter('main_table.status', ['in' => $this->_yotpoHelper->getCustomOrderStatus()])
                             ->addAttributeToFilter('main_table.store_id', $storeId)
                             ->addAttributeToFilter('main_table.created_at', ['gteq' => $this->_yotpoHelper->getOrdersSyncAfterDate()])
                             ->addAttributeToFilter('yotpo_sync.sync_flag', [['null' => true],['eq' => 0]])

--- a/Helper/ApiClient.php
+++ b/Helper/ApiClient.php
@@ -11,7 +11,7 @@ use Yotpo\Yotpo\Lib\Http\Client\Curl;
 
 class ApiClient extends \Magento\Framework\App\Helper\AbstractHelper
 {
-    const DEFAULT_TIMEOUT = 30;
+    const DEFAULT_TIMEOUT = 90;
 
     /**
      * @var int

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -474,6 +474,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function startEnvironmentEmulation($storeId, $area = Area::AREA_FRONTEND, $force = false)
     {
+        $this->stopEnvironmentEmulation();
         $this->getAppEmulation()->startEnvironmentEmulation($storeId, $area, $force);
         return $this;
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -52,11 +52,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected $_product;
 
     /**
-     * @var array
-     */
-    protected $_orderStatuses = [];
-
-    /**
      * @var StoreManagerInterface
      */
     protected $_storeManager;
@@ -359,15 +354,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getCustomOrderStatus($scopeId = null, $scope = null, $skipCahce = false)
     {
-        if (!$this->_orderStatuses) {
-            $this->_orderStatuses = $this->getConfig(self::XML_PATH_YOTPO_CUSTOM_ORDER_STATUS, $scopeId, $scope, $skipCahce);
-            if (!$this->_orderStatuses) {
-                $this->_orderStatuses = [Order::STATE_COMPLETE];
-            } else {
-                $this->_orderStatuses = array_map('strtolower', explode(',', $this->_orderStatuses));
-            }
-        }
-        return $this->_orderStatuses;
+        $orderStatuses = $this->getConfig(self::XML_PATH_YOTPO_CUSTOM_ORDER_STATUS, $scopeId, $scope, $skipCahce);
+        return ($orderStatuses) ? array_map('strtolower', explode(',', $orderStatuses)) : [Order::STATE_COMPLETE];
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -375,9 +375,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @param  string                 $format
      * @return date
      */
-    public function getOrdersSyncAfterDate($format = 'Y-m-d H:i:s')
+    public function getOrdersSyncAfterDate($scopeId = null, $scope = null, $format = 'Y-m-d H:i:s', $skipCahce = false)
     {
-        $timestamp = strtotime($this->getConfig(self::XML_PATH_YOTPO_ORDERS_SYNC_FROM_DATE) ?: $this->getCurrentDate());
+        $timestamp = strtotime($this->getConfig(self::XML_PATH_YOTPO_ORDERS_SYNC_FROM_DATE, $scopeId, $scope, $skipCahce) ?: $this->getCurrentDate());
         return date($format, $timestamp);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
     "name": "yotpo/module-review",
     "description": "Yotpo Reviews extension for Magento2",
-    "version": "2.8.1",
+    "version": "2.8.3",
     "require": {
-        "php": "~5.5.0|~5.6.0|^7.0",
-        "magento/framework": ">=100.1.0"
+        "php": "~5.6.0|^7.0",
+        "magento/framework": ">=101.0.0"
     },
     "type": "magento2-module",
     "autoload": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Yotpo" setup_version="2.8.1">
+    <module name="Yotpo_Yotpo" setup_version="2.8.3">
         <sequence>
             <module name="Magento_Catalog" />
         </sequence>

--- a/view/adminhtml/templates/system/config/sync_status.phtml
+++ b/view/adminhtml/templates/system/config/sync_status.phtml
@@ -5,6 +5,7 @@
 $status = $block->getStatus();
 ?>
 <!-- Yotpo Sync Status -->
-<div>Orders Synced: <?= $status['total_orders_synced'] . '/' . $status['total_orders'] ?></div>
-<div>Last Sync Date: <?= $status['last_sync_date'] ?></div>
+<div>Sync progress: <?= $status['total_orders_synced'] . '/' . $status['total_orders'] ?></div>
+<div>Last sync date: <?= $status['last_sync_date'] ?></div>
+<div>Total orders synced with Yotpo: <?= $status['total_orders_synced_all'] ?></div>
 <!--/ Yotpo Sync Status -->


### PR DESCRIPTION
* Officially removed support for Magento versions prior to 2.2.
* Fixed nesting emulation error.
* Increased curl timeout to 90 seconds.
* Removed scope-checkbox from Sync Status on store configuration.
* Fixed SyncStatus on Store Configuration to exclude disabled stores from the query.
* Fixed SyncStatus on Store Configuration to calculate each store by it's specific configurations.
* Added "Total orders synced with Yotpo" to SyncStatus.
* Fixed custom-order-status filtering to use 'in' instead of 'eq'.
* Added scopes support to getOrdersSyncAfterDate().
* Fixed Data::getCustomOrderStatus() to better support multi-store.
* Global improvements on multi-store support.