### PR TITLE
Replace string literal to :class keyword

### DIFF
--- a/Model/ResourceModel/Richsnippet/Collection.php
+++ b/Model/ResourceModel/Richsnippet/Collection.php
@@ -6,6 +6,9 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
 {
     protected function _construct()
     {
-        $this->_init('Yotpo\Yotpo\Model\Richsnippet', 'Yotpo\Yotpo\Model\ResourceModel\Richsnippet');
+        $this->_init(
+        	\Yotpo\Yotpo\Model\Richsnippet::class,
+        	\Yotpo\Yotpo\Model\ResourceModel\Richsnippet::class
+        );
     }
 }

--- a/Model/ResourceModel/Sync/Collection.php
+++ b/Model/ResourceModel/Sync/Collection.php
@@ -9,6 +9,9 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      */
     protected function _construct()
     {
-        $this->_init('Yotpo\Yotpo\Model\Sync', 'Yotpo\Yotpo\Model\ResourceModel\Sync');
+        $this->_init(
+        	\Yotpo\Yotpo\Model\Sync::class,
+        	\Yotpo\Yotpo\Model\ResourceModel\Sync::class
+        );
     }
 }

--- a/Model/Richsnippet.php
+++ b/Model/Richsnippet.php
@@ -5,7 +5,7 @@ class Richsnippet extends \Magento\Framework\Model\AbstractModel
 {
     protected function _construct()
     {
-        $this->_init('Yotpo\Yotpo\Model\ResourceModel\Richsnippet');
+        $this->_init(\Yotpo\Yotpo\Model\ResourceModel\Richsnippet::class);
     }
 
     public function isValid()

--- a/Model/Sync.php
+++ b/Model/Sync.php
@@ -8,6 +8,6 @@ class Sync extends \Magento\Framework\Model\AbstractModel
      */
     protected function _construct()
     {
-        $this->_init('Yotpo\Yotpo\Model\ResourceModel\Sync');
+        $this->_init(\Yotpo\Yotpo\Model\ResourceModel\Sync::class);
     }
 }


### PR DESCRIPTION
According Magento guidelines https://devdocs.magento.com/guides/v2.2/coding-standards/code-standard-php.html#literal-namespace-rule string literals should be replaced to ::class and it`s checked as right solution in Magento PHPCS from 2.2, but It works on previous versions too.  