### PR TITLE
Add missing dependency declare `Magento_Analytics`

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,6 +11,7 @@
             <module name="Magento_Review" />
             <module name="Magento_Sales" />
             <module name="Magento_Store" />
+            <module name="Magento_Analytics" />
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
In Magento 2.3.3, Yotpo module codes is depend on `Magento_Analytics` module. If we disable `Magento_Analytics`, Yotpo module will broken the backend. 

Involved file: 

`vendor/yotpo/magento2-module-yotpo-reviews/etc/acl.xml` and `vendor/yotpo/magento2-module-yotpo-reviews/etc/adminhtml/menu.xml`.

Related error report:

`{
"0":"Specified invalid parent id (Magento_Analytics::business_intelligence)",
"1":"<pre>#1 Magento\\Backend\\Model\\Menu\\Builder\\Interceptor->___callParent() called at [vendor\/magento\/framework\/Interception\/Interceptor.php:138]\n
#2 Magento\\Backend\\Model\\Menu\\Builder\\Interceptor->Magento\\Framework\\Interception\\{closure}() called at [vendor\/magento\/framework\/Interception\/Interceptor.php:153]\n
#3 Magento\\Backend\\Model\\Menu\\Builder\\Interceptor->___callPlugins() called at [generated\/code\/Magento\/Backend\/Model\/Menu\/Builder\/Interceptor.php:26]\n
#4 Magento\\Backend\\Model\\Menu\\Builder\\Interceptor->getResult() called at [vendor\/magento\/module-backend\/Model\/Menu\/Config.php:148]\n#5 Magento\\Backend\\Model\\Menu\\Config->_initMenu() called at [vendor\/magento\/module-backend\/Model\/Menu\/Config.php:111]\n#6 Magento\\Backend\\Model\\Menu\\Config->getMenu() called at [vendor\/magento\/module-backend\/Model\/Url.php:365]\n#7 Magento\\Backend\\Model\\Url->_getMenu() called at [vendor\/magento\/module-backend\/Model\/Url.php:325]\n#8 Magento\\Backend\\Model\\Url->getStartupPageUrl() called at [vendor\/magento\/module-backend\/App\/AbstractAction.php:281]\n#9 Magento\\Backend\\App\\AbstractAction->_processUrlKeys() called at [vendor\/magento\/module-backend\/App\/Request\/BackendValidator.php:175]\n#10 Magento\\Backend\\App\\Request\\BackendValidator->validate() called at [vendor\/magento\/framework\/App\/Request\/CompositeValidator.php:40]\n#11 Magento\\Framework\\App\\Request\\CompositeValidator->validate() called at [vendor\/magento\/framework\/App\/FrontController.php:138]\n#12 Magento\\Framework\\App\\FrontController->processRequest() called at [vendor\/magento\/framework\/App\/FrontController.php:99]\n#13 Magento\\Framework\\App\\FrontController->dispatch() called at [vendor\/magento\/framework\/Interception\/Interceptor.php:58]\n#14 Magento\\Framework\\App\\FrontController\\Interceptor->___callParent() called at [vendor\/magento\/framework\/Interception\/Interceptor.php:138]\n#15 Magento\\Framework\\App\\FrontController\\Interceptor->Magento\\Framework\\Interception\\{closure}() called at [vendor\/magento\/framework\/Interception\/Interceptor.php:153]\n#16 Magento\\Framework\\App\\FrontController\\Interceptor->___callPlugins() called at [generated\/code\/Magento\/Framework\/App\/FrontController\/Interceptor.php:26]\n#17 Magento\\Framework\\App\\FrontController\\Interceptor->dispatch() called at [vendor\/magento\/framework\/App\/Http.php:137]\n#18 Magento\\Framework\\App\\Http->launch() called at [vendor\/magento\/framework\/App\/Bootstrap.php:261]\n#19 Magento\\Framework\\App\\Bootstrap->run() called at [pub\/index.php:40]\n<\/pre>","url":"\/admin_1blw3c\/admin\/index\/index\/key\/062373892d973c709133151eea850662d7cdd9bb0170d065533b1ffea8818bbc\/","script_name":"\/index.php"}
`