### PR TITLE
Stop emulating on error during a sync

### DIFF
--- a/Model/Jobs/OrdersSync.php
+++ b/Model/Jobs/OrdersSync.php
@@ -171,6 +171,7 @@ class OrdersSync extends AbstractJobs
                     $this->emulateFrontendArea($storeId);
                     if (!$this->_yotpoConfig->isEnabled()) {
                         $this->_processOutput("OrdersSync::execute() - Skipping store ID: {$storeId} (disabled)", "debug");
+                        $this->stopEnvironmentEmulation();
                         continue;
                     }
                     $this->_processOutput("OrdersSync::execute() - Processing orders for store ID: {$storeId} ...", "debug");

--- a/Model/Jobs/UpdateMetadata.php
+++ b/Model/Jobs/UpdateMetadata.php
@@ -46,6 +46,7 @@ class UpdateMetadata extends AbstractJobs
                     $this->emulateFrontendArea($storeId);
                     if (!$this->_yotpoConfig->isEnabled()) {
                         $this->_processOutput("UpdateMetadata::execute() - Skipping store ID: {$storeId} (disabled)", "debug");
+                        $this->stopEnvironmentEmulation();
                         continue;
                     }
                     $this->_processOutput("UpdateMetadata::execute() - Updating metadata for store ID: {$storeId} ...", "debug");


### PR DESCRIPTION
When something is wrong during a sync and it goes to process the next store, the frontend emulation is not stopped, so there is error "Environment emulation nesting is not allowed." in the logs.  (the logs are from v.2.8.1, but it does not matter in this case, the reason is the same):

```
[2020-09-10 17:14:04] report.INFO: [Yotpo Log] "ApiClient::sendApiRequest() - request: " {"0":{"path":"oauth/token","params":{... },"store_id":"1" ...} []
[2020-09-10 17:14:07] report.INFO: [Yotpo Log] "ApiClient::sendApiRequest() - response: " {"status":502,"headers":{"Date":"Thu, 10 Sep 2020 17:14:07 GMT",...,"body":null,"store_id":"1" ...} []
[2020-09-10 17:14:07] report.ERROR: [Yotpo Log] "ApiClient::oauthAuthentication(, ) - error: no access token received" {...,"store_id":"1"..} []
[2020-09-10 17:14:07] report.ERROR: [Yotpo Log] "Jobs::ordersSync() - Error: Please make sure the APP KEY and SECRET you've entered are correct" {"store_id":"1","app_key": ...} []
[2020-09-10 17:14:07] report.ERROR: Environment emulation nesting is not allowed. [] []
```