### PR TITLE
Stop emulate if module is disabled for store

### DIFF
--- a/Model/Jobs/OrdersSync.php
+++ b/Model/Jobs/OrdersSync.php
@@ -171,6 +171,7 @@ class OrdersSync extends AbstractJobs
                     $this->emulateFrontendArea($storeId);
                     if (!$this->_yotpoConfig->isEnabled()) {
                         $this->_processOutput("OrdersSync::execute() - Skipping store ID: {$storeId} (disabled)", "debug");
+                        $this->stopEnvironmentEmulation();
                         continue;
                     }
                     $this->_processOutput("OrdersSync::execute() - Processing orders for store ID: {$storeId} ...", "debug");

--- a/Model/Jobs/UpdateMetadata.php
+++ b/Model/Jobs/UpdateMetadata.php
@@ -46,6 +46,7 @@ class UpdateMetadata extends AbstractJobs
                     $this->emulateFrontendArea($storeId);
                     if (!$this->_yotpoConfig->isEnabled()) {
                         $this->_processOutput("UpdateMetadata::execute() - Skipping store ID: {$storeId} (disabled)", "debug");
+                        $this->stopEnvironmentEmulation();
                         continue;
                     }
                     $this->_processOutput("UpdateMetadata::execute() - Updating metadata for store ID: {$storeId} ...", "debug");


### PR DESCRIPTION
To avoid "Environment emulation nesting is not allowed." error in the logs in case the module is disabled in some store.