### PR TITLE
Added PHP 8 to version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "AFL-3.0"
     ],
     "require": {
-        "php": "~5.6.0|^7.0",
+        "php": "~5.6.0|^7.0|^8.0.0|^8.1.0",
         "magento/framework": ">=101.0.0"
     },
     "type": "magento2-module",


### PR DESCRIPTION
LGTM!

```
$ vendor/bin/phpcs -p vendor/yotpo/magento2-module-yotpo-reviews --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.0 
................................................ 48 / 48 (100%)


Time: 1.54 secs; Memory: 14MB

$ vendor/bin/phpcs -p vendor/yotpo/magento2-module-yotpo-reviews --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.1
................................................ 48 / 48 (100%)


Time: 1.51 secs; Memory: 14MB

```